### PR TITLE
[FIX] auth_impersonate_user: Silence DeprecationWarning on logout.

### DIFF
--- a/auth_impersonate_user/controllers/main.py
+++ b/auth_impersonate_user/controllers/main.py
@@ -42,7 +42,7 @@ class ImpersonateHome(Home):
             request.session.login = request.session.impersonator_login
             del request.session["impersonator_uid"]
             del request.session["impersonator_login"]
-            request.env["res.users"].clear_caches()
+            request.env.registry.clear_cache()
             request.session.session_token = security.compute_session_token(request.session, request.env)
 
             return request.redirect(self._login_redirect(request.session.uid))


### PR DESCRIPTION
```
2025-12-03 17:45:19,606 82 WARNING odoo py.warnings: /usr/lib/python3/dist-packages/odoo/models.py:1956: DeprecationWarning: Deprecated model.clear_cache(), use registry.clear_cache() instead
   File "/usr/lib/python3.12/threading.py", line 1030, in _bootstrap
     self._bootstrap_inner()
   File "/usr/lib/python3.12/threading.py", line 1073, in _bootstrap_inner
     self.run()
   File "/usr/lib/python3.12/threading.py", line 1010, in run
     self._target(*self._args, **self._kwargs)
   File "/usr/lib/python3/dist-packages/odoo/service/server.py", line 1165, in _runloop
     self.process_work()
   File "/usr/lib/python3/dist-packages/odoo/service/server.py", line 1204, in process_work
     self.process_request(client, addr)
   File "/usr/lib/python3/dist-packages/odoo/service/server.py", line 1195, in process_request
     self.server.process_request(client, addr)
   File "/usr/lib/python3.12/socketserver.py", line 349, in process_request
     self.finish_request(request, client_address)
   File "/usr/lib/python3.12/socketserver.py", line 362, in finish_request
     self.RequestHandlerClass(request, client_address, self)
   File "/usr/lib/python3.12/socketserver.py", line 761, in __init__
     self.handle()
   File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 390, in handle
     super().handle()
   File "/usr/lib/python3.12/http/server.py", line 436, in handle
     self.handle_one_request()
   File "/usr/lib/python3.12/http/server.py", line 424, in handle_one_request
     method()
   File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 362, in run_wsgi
     execute(self.server.app)
   File "/usr/lib/python3/dist-packages/werkzeug/serving.py", line 323, in execute
     application_iter = app(environ, start_response)
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2578, in __call__
     response = request._serve_db()
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2105, in _serve_db
     return self._transactioning(
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2168, in _transactioning
     return service_model.retrying(func, env=self.env)
   File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 156, in retrying
     result = func()
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2135, in _serve_ir_http
     response = self.dispatcher.dispatch(rule.endpoint, args)
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 2296, in dispatch
     return self.request.registry['ir.http']._dispatch(endpoint)
   File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 333, in _dispatch
     result = endpoint(**request.params)
   File "/usr/lib/python3/dist-packages/odoo/http.py", line 756, in route_wrapper
     result = endpoint(self, *args, **params_ok)
   File "/mnt/extra-addons/mint/server-tools/auth_impersonate_user/controllers/main.py", line 25, in impersonate_user
     request.env["res.users"].clear_caches()
   File "/usr/lib/python3/dist-packages/odoo/models.py", line 1956, in clear_caches
     warnings.warn("Deprecated model.clear_cache(), use registry.clear_cache() instead", DeprecationWarning)
```