### PR TITLE
Update mail_mail.py

### DIFF
--- a/mail_format_with_parent/models/mail_mail.py
+++ b/mail_format_with_parent/models/mail_mail.py
@@ -40,6 +40,10 @@ class MailMail(models.Model):
                         )
                     ]
             else:
-                email_to = email_split_and_format(rec.get("email_to") or "")
+                raw_email_to = rec.get("email_to") or ""
+                if isinstance(raw_email_to, list):
+                    email_to = raw_email_to
+                else:
+                    email_to = email_split_and_format(raw_email_to)
             rec["email_to"] = email_to
         return results


### PR DESCRIPTION
The change ensures that if the `email_to` field is already a list, it is used directly, otherwise it is processed with the `email_split_and_format` function. This change is needed because when it is already a list with one item, it gets misinterpreted as an email addresses name without an email address added to it, resulting in an Assertion error: At least one valid recipient address should be specified for outgoing emails (To/Cc/Bcc)