### PR TITLE
Fix: session expired on impersonation (Windows/Mac)

### DIFF
--- a/auth_impersonate_user/controllers/main.py
+++ b/auth_impersonate_user/controllers/main.py
@@ -2,7 +2,6 @@ import logging
 
 from odoo import http
 from odoo.http import request
-from odoo.service import security
 
 from odoo.addons.web.controllers.home import Home
 
@@ -10,25 +9,44 @@ _logger = logging.getLogger(__name__)
 
 
 class ImpersonateHome(Home):
-    @http.route("/web/impersonate", type="http", auth="user", sitemap=False)
+    @http.route(
+        "/web/impersonate", type="http", auth="user", sitemap=False, readonly=True
+    )
     def impersonate_user(self, **kw):
         uid = request.env.user.id
         if request.env.user.can_impersonate_user:
-            _logger.info("User <%s> impersonates user <%s>.", uid, int(request.params["uid"]))
+            target_uid = int(request.params["uid"])
+            _logger.info("User <%s> impersonates user <%s>.", uid, target_uid)
 
             # Backup original session info
             request.session["impersonator_uid"] = request.session.uid
-            request.session["impersonator_login"] = request.session.uid
+            request.session["impersonator_login"] = request.session.login
 
-            # Set new session info
-            uid = request.session.uid = int(request.params["uid"])
-            request.env["res.users"]._invalidate_cache()
-            request.session.session_token = security.compute_session_token(request.session, request.env)
+            # Switch session to the target user
+            uid = request.session.uid = target_uid
+            target_user = request.env["res.users"].sudo().browse(target_uid)
+            request.session.login = target_user.login
+            request.session.context = dict(
+                request.env["res.users"].with_user(target_uid).context_get()
+            )
+
+            # Invalidate all ormcaches — _compute_session_token is keyed
+            # by session id (not uid), so switching users requires a
+            # fresh computation.
+            request.env.registry.clear_cache()
+
+            # Force a hard session rotation: generates a completely new
+            # session ID and deletes the old session file.  This prevents
+            # concurrent requests (bus polls, pending RPCs) that still
+            # hold the old session data from overwriting the impersonated
+            # session.  rotate() also recomputes session_token for the
+            # new uid/sid automatically.
+            request.session.should_rotate = True
 
         return request.redirect(self._login_redirect(uid))
 
-    @http.route("/web/session/logout", type="http", auth="none")
-    def logout(self, redirect="/web"):
+    @http.route("/web/session/logout", type="http", auth="none", readonly=True)
+    def logout(self, redirect="/odoo"):
         # Exit impersonation first
         if request.session.get("impersonator_uid"):
             _logger.info(
@@ -37,13 +55,23 @@ class ImpersonateHome(Home):
                 request.session.uid,
             )
 
-            # Restore session info
-            request.session.uid = request.session.get("impersonator_uid")
-            request.session.login = request.session.get("impersonator_login")
-            del request.session["impersonator_uid"]
-            del request.session["impersonator_login"]
+            # Restore original session info
+            original_uid = request.session.pop("impersonator_uid")
+            original_login = request.session.pop("impersonator_login")
+
+            request.session.uid = original_uid
+            request.session.login = original_login
+            request.session.context = dict(
+                request.env["res.users"].sudo().with_user(original_uid).context_get()
+            )
+
             request.env.registry.clear_cache()
-            request.session.session_token = security.compute_session_token(request.session, request.env)
+
+            # Hard-rotate the session for the same reason as above:
+            # isolate the restored admin session from any in-flight
+            # requests that still reference the impersonated user's
+            # session data.
+            request.session.should_rotate = True
             return request.redirect(self._login_redirect(request.session.uid))
         request.session.logout(keep_db=True)
         return request.redirect(redirect, 303)

--- a/auth_impersonate_user/models/res_users.py
+++ b/auth_impersonate_user/models/res_users.py
@@ -13,12 +13,16 @@ class ResUsers(models.Model):
 
     def _compute_can_impersonate_user(self):
         for user in self:
-            user.can_impersonate_user = self.env.user.has_group("auth_impersonate_user.impersonate_admin_group")
+            user.can_impersonate_user = self.env.user.has_group(
+                "auth_impersonate_user.impersonate_admin_group"
+            )
 
     def _compute_can_be_impersonated(self):
         for user in self:
             user.can_be_impersonated = (
-                user.has_group("auth_impersonate_user.impersonate_user_group") if self.env.user != user else False
+                user.has_group("auth_impersonate_user.impersonate_user_group")
+                if self.env.user != user
+                else False
             )
 
     def impersonate_user(self):


### PR DESCRIPTION
### Problem

Impersonating a user works on Linux Mint/Chrome but intermittently fails on Windows 11 and Mac (Chrome/Edge). Users see:
> "Your Odoo session expired. The current page is about to be refreshed."

Then redirected to the login screen instead of the impersonated user's home.

### Root Cause

The impersonation controller modified the session file in-place without changing the session ID. Concurrent requests - bus long-polls, SharedWorker WebSocket connections, pending RPCs - that loaded the session _before_ impersonation could write stale data back to the same session file, overwriting the impersonation changes.

The initial GET to `/odoo` after redirect would succeed (session file momentarily correct), but a subsequent RPC call would hit the reverted session data and trigger `SessionExpiredException`. The "session expired" popup comes exclusively from failed JSON-RPC calls, not from page loads.

This was OS/browser-dependant because it's a timing race: faster machines with more aggressive prefetch or bus polling are more likely to trigger the overwrite.

### Fix

Replaced manual `compute_session_token()` with `request.session.should_rotate = True` in both the impersonation and de-impersonation flows.

Hard Session rotation (`http.py FilesystemSessionStore.rotate()`):
1. Deletes the old session file
2. Generates a completely new session ID
3. Recomputes the session token for the new uid/sid
4. Saves to a new session file
5. Sets a new `session_id` cookie on the response

Even if a concurrent request overwrites the old (now-deleted) session file, it's irrelevant - the browser's cookie points to the new file. The stale session ID is orphaned and garbage-collected.

### Changes

`controllers/main.py`:
- Remove manual `security.compute_session_token()` calls from both flows
- Added `request.session.should_rotate = True` to both impersonation and de-impersonation
- Kept `registry.clear_cache()` (invalidates ormcaches when switching user context, same as /web/become)
- Remove unused `from odoo.service import security` import

### Prior fix (insufficient)

The first attempt replaced `_invalidate_cache()` with `registry.clear_cache()` and manually called `compute_session_token()`. This fixed the ormcache key issue but did not address the concurrent request race condition because the session ID remained the same.
